### PR TITLE
Handle link coloring in pre elements

### DIFF
--- a/public_html/index.html
+++ b/public_html/index.html
@@ -4,7 +4,12 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Validation Ledger &amp; Transaction Store</title>
+    <meta name="format-detection" content="telephone=no">
+    <meta name="format-detection" content="date=no">
+    <meta name="format-detection" content="address=no">
+    <meta name="format-detection" content="email=no">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+    <style>pre a{color:inherit;text-decoration:none}</style>
   </head>
   <body>
     <div class="container">


### PR DESCRIPTION
Some mobile browsers can interpret numbers as phone numbers and create links automatically, this change will color those links so they are visible. In case of blue pre, links inside were also blue, this will force links to be same color as text. This visual bug is reproducible on "Puma" we browser for iOS.